### PR TITLE
Adding support for custom annotations on pods

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -13,6 +13,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "kafka-lag-exporter.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Value.podAnnotations | indent 8 }}
+      {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
This is necessary to allow datadog to autodiscover prometheus metrics based on pod annotations.